### PR TITLE
Point Rediff users to the Facet monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # rediff
 
+> [!IMPORTANT]
+> Rediff has moved to the Facet monorepo:
+> <https://github.com/facet-rs/facet/tree/main/rediff>.
+>
+> Please open future issues and pull requests in
+> <https://github.com/facet-rs/facet>. This standalone repository is retained
+> for history and archival purposes.
+
 Structural diffing and assertions for [Facet](https://github.com/bearcove/facet) types.
 
 Compare any Facet-derived type without requiring `PartialEq` - rediff uses reflection to compare values structurally and produce detailed, colorized diff output.


### PR DESCRIPTION
## Summary

Adds a top-level README notice pointing Rediff users to its new home in the Facet monorepo:
https://github.com/facet-rs/facet/tree/main/rediff

## Testing

- pre-commit checks passed

## Notes

The old repository pre-push hook currently fails `cargo doc --no-deps -p rediff --all-features` on an existing rustdoc private intra-doc link warning in `src/hexdump.rs`. This PR only changes the README redirect notice, so the branch was pushed with `--no-verify`.
