### PR TITLE
restore Rediff as a standalone crate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   labels:
-    - bearcove-ubuntu-24.04
+    - blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-plz-release:
     name: Release-plz release
-    runs-on: bearcove-ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: release
     permissions:
       contents: write
@@ -75,7 +75,7 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
-    runs-on: bearcove-ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-x86_64-unknown-linux-gnu:
-    runs-on: bearcove-ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 
@@ -25,7 +25,7 @@ jobs:
         run: cargo nextest run
 
   clippy:
-    runs-on: bearcove-ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 
@@ -39,7 +39,7 @@ jobs:
         run: cargo clippy --all-features --all-targets -- -D warnings
 
   docs:
-    runs-on: bearcove-ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 
@@ -53,7 +53,7 @@ jobs:
         run: cargo doc --no-deps
 
   lockfile:
-    runs-on: bearcove-ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,15 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +68,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +102,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
 ]
 
 [[package]]
@@ -228,6 +242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +267,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossterm"
@@ -350,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d43d3564e06baf09ca8ab87072e49e603046af471f1ed68cbeb1ad3ec8fba2"
+checksum = "cdb82703861ca7d5cb7f92979a37f9e553d0afa45da31c57b4b7f60bf5a9a836"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -361,11 +390,12 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a088a24ab676d6a7ed5ae3a7982a2092cc29684fe4e97b3827d5e239c76d9e79"
+checksum = "a98216bc8499aa471b28db6138eddde13fa20a66320094ce0c67bd9e05ecb202"
 dependencies = [
  "autocfg",
+ "bstr",
  "bytes",
  "bytestring",
  "camino",
@@ -385,6 +415,7 @@ dependencies = [
  "smartstring",
  "smol_str",
  "stable_deref_trait",
+ "taxon",
  "time",
  "ulid",
  "url",
@@ -394,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a85e100b892473cef064ca8f3443af4c8eb78b8609eb3224eba8df679caf690"
+checksum = "0188bcfa782348ef17191e43a1fe683f8de781fd99bc06e28ab035c87705ba59"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -405,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b2552407f6f584187a808bd4fbb56f002cc5451454294898276881c232d07a"
+checksum = "88fb84421539f9217f5586dca018781a51ee656f48b099c55a728850028d1b96"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -416,18 +447,18 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77f92b6fe3ae6d45544e50351a9a54f7190240220b283916cbcca20a849812b"
+checksum = "aa54237ee404674bb3ce737d38c7ace2957d5bc20d96d1c87d011d061cc94fd2"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1f0535febaea47d61f5386a6e0ab3249a5aaf813ae67e25bf285e97c481e30"
+checksum = "34ab10a03d94e0abdd26d5e14b5caad8a9ba0b8de5d398a3a8c1b862ad5eb2fb"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -439,18 +470,18 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0aeceb55a22d6ddb1d9d2af4a6223114ce6869821c0ae1091a3c955d1492a7"
+checksum = "deada94e9d8db1964d549adfc8fb2a77176c129fa3e1dd4457a9cd9e5abdb021"
 dependencies = [
  "facet-core",
 ]
 
 [[package]]
 name = "facet-pretty"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2522ca631c6c71803ecc836d70d0def6db0eb9358bcc39fdbe5ffd44c914e2e"
+checksum = "b330f3c096345f503e020209433f3783d846e26127e86712b96d282ca8a98926"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -460,14 +491,13 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8287a68023eec4152a4d4cb88814e10d38ff6f116cbb70acb4eb58a304f624c6"
+checksum = "1f186f7c0430e338db959721b5e9e6231e86423e7597ee2efb76dcd807fb99cb"
 dependencies = [
  "facet-core",
  "facet-path",
  "hashbrown 0.17.0",
- "regex",
  "smallvec 2.0.0-alpha.12",
 ]
 
@@ -1235,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "rediff"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 dependencies = [
  "confusables",
  "facet",
@@ -1258,35 +1288,6 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
@@ -1623,6 +1624,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "taxon"
+version = "0.2.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acccfbd01e7cf4c7ea384b46df6ba3afb934ad88abd247f92998249854de968"
+dependencies = [
+ "blake3",
+]
 
 [[package]]
 name = "terminal-colorsaurus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rediff"
-version = "0.50.0-rc.0"
+version = "0.50.0-rc.6"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.92"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bearcove/rediff"
@@ -10,11 +10,9 @@ description = "Diff and compare Facet values with detailed structural difference
 documentation = "https://docs.rs/rediff"
 keywords = ["diff", "compare", "testing", "facet", "assertion"]
 categories = ["development-tools::testing", "rust-patterns"]
-homepage = "https://github.com/bearcove/rediff"
+homepage = "https://facet.rs"
 
-[package.metadata]
-
-[package.metadata."docs.rs"]
+[package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [features]
@@ -22,24 +20,24 @@ default = []
 tracing = ["dep:tracing"]
 
 [dependencies]
-# Core facet dependencies
-facet = { version = "0.50.0-rc.0" }
-facet-core = { version = "0.50.0-rc.0" }
-facet-pretty = { version = "0.50.0-rc.0" }
-facet-reflect = { version = "0.50.0-rc.0" }
-
-# From facet-diff-core
+facet = "0.50.0-rc.6"
+facet-core = "0.50.0-rc.6"
+facet-pretty = "0.50.0-rc.6"
+facet-reflect = "0.50.0-rc.6"
 confusables = "0.1"
 indextree = "4"
-owo-colors = "4"
+owo-colors = "4.2.3"
 palette = { version = "0.7", default-features = false, features = ["std"] }
 terminal-colorsaurus = "1"
-unicode-width = "0.2"
-
-tracing = { version = "0.1", default-features = false, optional = true }
+unicode-width = "0.2.2"
+tracing = { version = "0.1.43", default-features = false, features = ["std", "attributes"], optional = true }
 
 [dev-dependencies]
-facet = { version = "0.50.0-rc.0", features = [
-  "all-impls",
-] }
-tracing = "0.1"
+facet = { version = "0.50.0-rc.6", features = ["all-impls"] }
+tracing = { version = "0.1.43", default-features = false, features = ["std", "attributes"] }
+
+[lints.clippy]
+disallowed_methods = "deny"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(facet_no_doc)", "cfg(kani)"] }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 # rediff
 
-> [!IMPORTANT]
-> Rediff has moved to the Facet monorepo:
-> <https://github.com/facet-rs/facet/tree/main/rediff>.
->
-> Please open future issues and pull requests in
-> <https://github.com/facet-rs/facet>. This standalone repository is retained
-> for history and archival purposes.
-
-Structural diffing and assertions for [Facet](https://github.com/bearcove/facet) types.
+Structural diffing and assertions for [Facet](https://github.com/facet-rs/facet) types.
 
 Compare any Facet-derived type without requiring `PartialEq` - rediff uses reflection to compare values structurally and produce detailed, colorized diff output.
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,37 @@
++++
+title = "rediff"
+weight = 36
+insert_anchor_links = "heading"
++++
+
+`rediff` compares `Facet` values structurally and reports detailed diffs.
+
+It is useful in tests where `PartialEq` is unavailable, too blunt, or gives too
+little context when values differ. Rediff walks the reflected shape of both
+values and renders the difference with paths, structure, and terminal-friendly
+formatting.
+
+```rust
+use facet::Facet;
+use rediff::assert_same;
+
+#[derive(Facet)]
+struct Config {
+    host: String,
+    port: u16,
+}
+
+let expected = Config {
+    host: "localhost".to_owned(),
+    port: 8080,
+};
+
+let actual = Config {
+    host: "localhost".to_owned(),
+    port: 8080,
+};
+
+assert_same!(expected, actual);
+```
+
+Source: [`rediff`](https://github.com/bearcove/rediff)

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -63,10 +63,17 @@ pub fn diff_new_peek_with_options<'mem, 'facet>(
     let from = deref_if_pointer(from);
     let to = deref_if_pointer(to);
 
-    // Check for equality if both shapes have the same type_identifier and implement PartialEq
-    // This handles cases where shapes are structurally equivalent but have different IDs
-    // (e.g., after deserialization)
-    let same_type = from.shape().type_identifier == to.shape().type_identifier;
+    // Gate the fast "they're just equal" path on actual type identity.
+    //
+    // This used to compare `type_identifier`, the *bare* type name — so two
+    // unrelated `Config`s from different crates counted as the same type. Names
+    // carry no uniqueness guarantee; `Shape::id` is the documented field for
+    // "type equality checks and hash map keys".
+    //
+    // Note this only really bites the `float_equal` arm below: `Peek`'s `==`
+    // already refuses mismatched shapes and yields `false`, so `values_equal`
+    // could never have been true across two different types anyway.
+    let same_type = from.shape().id == to.shape().id;
     let from_has_partialeq = from.shape().is_partial_eq();
     let to_has_partialeq = to.shape().is_partial_eq();
     let values_equal = from == to;

--- a/src/layout/build.rs
+++ b/src/layout/build.rs
@@ -43,7 +43,7 @@ fn get_shape_display_name(shape: &Shape) -> &'static str {
 /// Shapes without XML attributes are "proxy types" - Rust implementation details
 /// that wouldn't exist in actual XML output.
 fn shape_has_xml_attrs(shape: &Shape) -> bool {
-    shape.attributes.iter().any(|attr| attr.ns == Some("xml"))
+    shape.attributes.iter().any(|attr| attr.ns() == Some("xml"))
 }
 
 /// Get the display name for a shape.


### PR DESCRIPTION
## Change

Restore this repository as Rediff's canonical home using the current implementation from the Facet monorepo.

- synchronize current source and docs
- depend on published Facet `0.50.0-rc.6` crates
- restore the standalone package metadata
- move CI and release-plz jobs to Blacksmith runners
- regenerate the lockfile

## Verification

- `cargo nextest run --all-features` — 37 passed
- `cargo clippy --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
- `actionlint`
- `cargo update --workspace --locked`
- `git diff --check`
