### PR TITLE
release: configure trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,44 +15,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Get crates.io token via OIDC
+        uses: rust-lang/crates-io-auth-action@v1.0.5
         id: crates-io-auth
-        shell: bash
-        env:
-          REGISTRY_URL: https://crates.io
-        run: |
-          set -euo pipefail
-          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
-            echo "::error::Please ensure the 'id-token' permission is set to 'write' in your workflow."
-            exit 1
-          fi
-
-          oidc_url="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=crates.io"
-          jwt="$(curl -fsSL -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${oidc_url}" | jq -r '.value')"
-          if [ -z "${jwt}" ] || [ "${jwt}" = "null" ]; then
-            echo "::error::Failed to retrieve GitHub Actions OIDC token"
-            exit 1
-          fi
-
-          token="$(jq -n --arg jwt "${jwt}" '{jwt: $jwt}' \
-            | curl -fsSL -X POST "${REGISTRY_URL}/api/v1/trusted_publishing/tokens" \
-                -H "Content-Type: application/json" \
-                -H "User-Agent: crates-io-auth-shell/1" \
-                --data @- \
-            | jq -r '.token')"
-          if [ -z "${token}" ] || [ "${token}" = "null" ]; then
-            echo "::error::Failed to retrieve crates.io token"
-            exit 1
-          fi
-
-          echo "::add-mask::${token}"
-          echo "token=${token}" >> "${GITHUB_OUTPUT}"
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
@@ -60,18 +31,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-      - name: Revoke crates.io token
-        if: always() && steps.crates-io-auth.outputs.token != ''
-        shell: bash
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-          REGISTRY_URL: https://crates.io
-        run: |
-          set -euo pipefail
-          curl -fsSL -X DELETE "${REGISTRY_URL}/api/v1/trusted_publishing/tokens" \
-            -H "Authorization: Bearer ${CARGO_REGISTRY_TOKEN}" \
-            -H "User-Agent: crates-io-auth-shell/1" \
-            --output /dev/null
 
   release-plz-pr:
     name: Release-plz PR
@@ -84,7 +43,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,23 @@ owo-colors = "4.2.3"
 palette = { version = "0.7", default-features = false, features = ["std"] }
 terminal-colorsaurus = "1"
 unicode-width = "0.2.2"
-tracing = { version = "0.1.43", default-features = false, features = ["std", "attributes"], optional = true }
+tracing = { version = "0.1.43", default-features = false, features = [
+  "std",
+  "attributes",
+], optional = true }
 
 [dev-dependencies]
 facet = { version = "0.50.0-rc.6", features = ["all-impls"] }
-tracing = { version = "0.1.43", default-features = false, features = ["std", "attributes"] }
+tracing = { version = "0.1.43", default-features = false, features = [
+  "std",
+  "attributes",
+] }
 
 [lints.clippy]
 disallowed_methods = "deny"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(facet_no_doc)", "cfg(kani)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(facet_no_doc)",
+  "cfg(kani)",
+] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,9 @@
+[workspace]
+changelog_update = true
+semver_check = true
+dependencies_update = true
+git_release_enable = true
+
+[[package]]
+name = "rediff"
+changelog_path = "CHANGELOG.md"


### PR DESCRIPTION
## Change

- add the missing `release-plz.toml` for Rediff
- replace the hand-written crates.io OIDC exchange with `rust-lang/crates-io-auth-action@v1.0.5`
- update checkout to v7
- apply current Taplo formatting to `Cargo.toml`

The crates.io trusted publisher has been migrated from `facet-rs/facet` to `bearcove/rediff` with `tp`.

## Verification

- `tp cargo bearcove rediff --workflow release-plz.yml --dry-run` — configured
- authenticated `release-plz release --dry-run` — rc.6 already published
- `actionlint`
- `taplo fmt --check Cargo.toml release-plz.toml`
- `git diff --check`
